### PR TITLE
#634 | Implement code signing for all BMC,  MissionControlBridge and MissionControlTowerSDK dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
         dir
         .\build_and_stage.bat ${{ matrix.arch_cmake }}
 
-      - name: Windows Signing
+    - name: Windows Signing
       if: runner.os == 'windows-latest'
       uses: GabrielAcostaEngler/signtool-code-sign@main
       with:


### PR DESCRIPTION
> [!CAUTION]
>  In order to sign the artifacts and installers correctly, the following secrets must be set in this repo's settings:
> - `WINDOWS_CERTIFICATE_BASE64`
> - `WINDOWS_CERTIFICATE_PASSWORD`
> - `WINDOWS_CERTIFICATE_SHA1`

# Resolves

[BMC2-634](https://focusuy.atlassian.net/browse/BMC2-634)

# How to test

1. Go to [this repo's Actions](https://github.com/binhollc/MissionControlTowerSDK/actions).
2. In the right menu, select the [Build](https://github.com/binhollc/MissionControlTowerSDK/actions/workflows/build.yml) workflow.
3. In the `Run workflow` dropdown select the branch `jurrisa-634`.
4. Click `Run workflow`

# What to expect

- The workflows should run successfully, generating the Windows artifacts and installers.
- When downloading and installing the generated artifacts and installers in Windows, it should not pop up any warnings (as the artifacts should be signed). 