### PR TITLE
1483 | Amends branch 1483-jurrisa

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build and Package BMC SDK
 env:
   VERSION: 1.1.0
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  PYTHON_VERSION: 3.11
 
 on:
   workflow_dispatch:
@@ -47,7 +48,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: ${{ env.PYTHON_VERSION }}
         architecture: ${{ matrix.arch_python }}
 
     - name: Get CMake
@@ -90,7 +91,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: ${{ env.PYTHON_VERSION }}
         architecture: ${{ matrix.arch_python }}
 
     - name: Get CMake
@@ -138,7 +139,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: ${{ env.PYTHON_VERSION }}
         architecture: ${{ matrix.arch_python }}
 
     - name: Get CMake


### PR DESCRIPTION
**Changes**

- Removes duplication of definition of `GH_TOKEN` environment variable.
- Extracts the Python version to a global variable.