### PR TITLE
1488 | Resolve DYLD Library Loading Issue for sample_app

### DIFF
--- a/examples/i3c_ICM42605/CMakeLists.txt
+++ b/examples/i3c_ICM42605/CMakeLists.txt
@@ -33,3 +33,13 @@ install(TARGETS ${TARGET_NAME} RUNTIME DESTINATION ${STAGING_DIR}/examples/${TAR
 
 # Install the source files
 install(FILES ${SOURCES} DESTINATION ${STAGING_DIR}/examples/${TARGET_NAME})
+
+# ---
+# Post-installation steps to set RPATH only on macOS
+# ---
+
+if(APPLE)
+    install(CODE "
+      execute_process(COMMAND install_name_tool -add_rpath @loader_path/../../lib ${STAGING_DIR}/examples/${TARGET_NAME}/sample_app)
+    ")
+endif()

--- a/examples/i3c_cccs/CMakeLists.txt
+++ b/examples/i3c_cccs/CMakeLists.txt
@@ -33,3 +33,13 @@ install(TARGETS ${TARGET_NAME} RUNTIME DESTINATION ${STAGING_DIR}/examples/${TAR
 
 # Install the source files
 install(FILES ${SOURCES} DESTINATION ${STAGING_DIR}/examples/${TARGET_NAME})
+
+# ---
+# Post-installation steps to set RPATH only on macOS
+# ---
+
+if(APPLE)
+    install(CODE "
+      execute_process(COMMAND install_name_tool -add_rpath @loader_path/../../lib ${STAGING_DIR}/examples/${TARGET_NAME}/sample_app)
+    ")
+endif()

--- a/examples/i3c_ibis/CMakeLists.txt
+++ b/examples/i3c_ibis/CMakeLists.txt
@@ -33,3 +33,13 @@ install(TARGETS ${TARGET_NAME} RUNTIME DESTINATION ${STAGING_DIR}/examples/${TAR
 
 # Install the source files
 install(FILES ${SOURCES} DESTINATION ${STAGING_DIR}/examples/${TARGET_NAME})
+
+# ---
+# Post-installation steps to set RPATH only on macOS
+# ---
+
+if(APPLE)
+    install(CODE "
+      execute_process(COMMAND install_name_tool -add_rpath @loader_path/../../lib ${STAGING_DIR}/examples/${TARGET_NAME}/sample_app)
+    ")
+endif()

--- a/examples/list_devices/CMakeLists.txt
+++ b/examples/list_devices/CMakeLists.txt
@@ -33,3 +33,13 @@ install(TARGETS ${TARGET_NAME} RUNTIME DESTINATION ${STAGING_DIR}/examples/${TAR
 
 # Install the source files
 install(FILES ${SOURCES} DESTINATION ${STAGING_DIR}/examples/${TARGET_NAME})
+
+# ---
+# Post-installation steps to set RPATH only on macOS
+# ---
+
+if(APPLE)
+    install(CODE "
+      execute_process(COMMAND install_name_tool -add_rpath @loader_path/../../lib ${STAGING_DIR}/examples/${TARGET_NAME}/sample_app)
+    ")
+endif()

--- a/examples/mock_notifications/CMakeLists.txt
+++ b/examples/mock_notifications/CMakeLists.txt
@@ -33,3 +33,13 @@ install(TARGETS ${TARGET_NAME} RUNTIME DESTINATION ${STAGING_DIR}/examples/${TAR
 
 # Install the source files
 install(FILES ${SOURCES} DESTINATION ${STAGING_DIR}/examples/${TARGET_NAME})
+
+# ---
+# Post-installation steps to set RPATH only on macOS
+# ---
+
+if(APPLE)
+    install(CODE "
+      execute_process(COMMAND install_name_tool -add_rpath @loader_path/../../lib ${STAGING_DIR}/examples/${TARGET_NAME}/sample_app)
+    ")
+endif()

--- a/examples/nova_breathing_leds/CMakeLists.txt
+++ b/examples/nova_breathing_leds/CMakeLists.txt
@@ -33,3 +33,13 @@ install(TARGETS ${TARGET_NAME} RUNTIME DESTINATION ${STAGING_DIR}/examples/${TAR
 
 # Install the source files
 install(FILES ${SOURCES} DESTINATION ${STAGING_DIR}/examples/${TARGET_NAME})
+
+# ---
+# Post-installation steps to set RPATH only on macOS
+# ---
+
+if(APPLE)
+    install(CODE "
+      execute_process(COMMAND install_name_tool -add_rpath @loader_path/../../lib ${STAGING_DIR}/examples/${TARGET_NAME}/sample_app)
+    ")
+endif()

--- a/examples/sample_app_using_sample_library/CMakeLists.txt
+++ b/examples/sample_app_using_sample_library/CMakeLists.txt
@@ -34,3 +34,14 @@ install(TARGETS ${TARGET_NAME} RUNTIME DESTINATION ${STAGING_DIR}/examples/${TAR
 
 # Install the source files
 install(FILES ${SOURCES} DESTINATION ${STAGING_DIR}/examples/${TARGET_NAME})
+
+# ---
+# Post-installation steps to set RPATH only on macOS
+# ---
+
+if(APPLE)
+    install(CODE "
+      execute_process(COMMAND install_name_tool -add_rpath @loader_path/../../lib ${STAGING_DIR}/examples/${TARGET_NAME}/sample_app)
+      execute_process(COMMAND install_name_tool -add_rpath @loader_path/../sample_library ${STAGING_DIR}/examples/${TARGET_NAME}/sample_app)
+    ")
+endif()

--- a/examples/supernova_101/CMakeLists.txt
+++ b/examples/supernova_101/CMakeLists.txt
@@ -33,3 +33,13 @@ install(TARGETS ${TARGET_NAME} RUNTIME DESTINATION ${STAGING_DIR}/examples/${TAR
 
 # Install the source files
 install(FILES ${SOURCES} DESTINATION ${STAGING_DIR}/examples/${TARGET_NAME})
+
+# ---
+# Post-installation steps to set RPATH only on macOS
+# ---
+
+if(APPLE)
+    install(CODE "
+      execute_process(COMMAND install_name_tool -add_rpath @loader_path/../../lib ${STAGING_DIR}/examples/${TARGET_NAME}/sample_app)
+    ")
+endif()

--- a/examples/supernova_i2c/CMakeLists.txt
+++ b/examples/supernova_i2c/CMakeLists.txt
@@ -33,3 +33,13 @@ install(TARGETS ${TARGET_NAME} RUNTIME DESTINATION ${STAGING_DIR}/examples/${TAR
 
 # Install the source files
 install(FILES ${SOURCES} DESTINATION ${STAGING_DIR}/examples/${TARGET_NAME})
+
+# ---
+# Post-installation steps to set RPATH only on macOS
+# ---
+
+if(APPLE)
+    install(CODE "
+      execute_process(COMMAND install_name_tool -add_rpath @loader_path/../../lib ${STAGING_DIR}/examples/${TARGET_NAME}/sample_app)
+    ")
+endif()

--- a/examples/supernova_i2c_benchmark/CMakeLists.txt
+++ b/examples/supernova_i2c_benchmark/CMakeLists.txt
@@ -33,3 +33,13 @@ install(TARGETS ${TARGET_NAME} RUNTIME DESTINATION ${STAGING_DIR}/examples/${TAR
 
 # Install the source files
 install(FILES ${SOURCES} DESTINATION ${STAGING_DIR}/examples/${TARGET_NAME})
+
+# ---
+# Post-installation steps to set RPATH only on macOS
+# ---
+
+if(APPLE)
+    install(CODE "
+      execute_process(COMMAND install_name_tool -add_rpath @loader_path/../../lib ${STAGING_DIR}/examples/${TARGET_NAME}/sample_app)
+    ")
+endif()


### PR DESCRIPTION
**Resolves**

- https://focusuy.atlassian.net/browse/BMC2-1488

**Changes**

- Adds an extra step to add rpath to the examples' executables (only required by macOS).

**How to test**

- Download the binaries on your macOS.
- Update the PATH variable to include the bridge's path.
- Execute examples/**/sample_app

