### PR TITLE
1491 | Sample App Shouldn't Hang When Running sample_library Example in macOS

### DIFF
--- a/examples/sample_library/sample_library.cpp
+++ b/examples/sample_library/sample_library.cpp
@@ -23,7 +23,7 @@ std::string SampleLibrary::get_address() {
 
     dispatcher.waitForAllCommands();
 
-    dispatcher.invokeCommand("0", "exit", {});
+    dispatcher.invokeCommandSync("0", "exit", {});
 
     dispatcher.stop();
 


### PR DESCRIPTION
**Resolves**

- https://focusuy.atlassian.net/browse/BMC2-1491

**How to test**

- Navigate to the project's base directory.
- Verify that there's no `output.txt` file.
- Run `build_and_test.sh`.
- Execute `staging/examples/sample_app_using_sample_library/sample_app`.
- Verify that there's an `output.txt` file containing something like:

```
DevSrvsID:4319070293
2.4.0
B
3E4F7B5A90829354A3310760E9ABD995
```