### PR TITLE
1536 | Update Compatibility List to Include Bridge v0.13

### DIFF
--- a/src/CommandManager.cpp
+++ b/src/CommandManager.cpp
@@ -18,7 +18,7 @@
 
 using json = nlohmann::json;
 
-#define ALLOWED_VERSIONS {"0.12"}
+#define ALLOWED_VERSIONS {"0.12", "0.13"}
 
 bool checkVersionCompatibility(std::string versionStr) {
     // Verify only MAJOR and MINOR


### PR DESCRIPTION
> [!WARNING]
> It is recommended to merge #36 first

**Resolves**

- https://focusuy.atlassian.net/browse/BMC2-1536

**How to test**

- Download Bridge 0.13
- Update PATH
- Navigate to MissionControlTowerSDK's base path
- Verify that the bridge version is 0.13: `bridge --version`
- Run examples