### PR TITLE
1630 | Add link to `pthread` library on C++ CDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,10 @@ target_include_directories(bmc_sdk PUBLIC
     ${PROJECT_SOURCE_DIR}/include
 )
 
-target_link_libraries(bmc_sdk PRIVATE nlohmann_json::nlohmann_json pthread)
+target_link_libraries(bmc_sdk PRIVATE nlohmann_json::nlohmann_json)
+if(UNIX)
+    target_link_libraries(bmc_sdk PRIVATE pthread)
+endif()
 
 target_compile_features(bmc_sdk PUBLIC cxx_std_17)
 
@@ -89,6 +92,9 @@ target_include_directories(bmc_sdk_static PUBLIC
 )
 
 target_link_libraries(bmc_sdk_static PRIVATE nlohmann_json::nlohmann_json)
+if(UNIX)
+    target_link_libraries(bmc_sdk_static PRIVATE pthread)
+endif()
 
 target_compile_features(bmc_sdk_static PUBLIC cxx_std_17)
 


### PR DESCRIPTION
Resolves https://focusuy.atlassian.net/browse/BMC2-1630
# :warning: Important :warning: 
The following PR should be merged first
- #38 

# How to test
Compile it in
- Windows
- Linux
- Mac
Using the main CMakeFiles.txt file.

# Expected result
No compiling or linking errors are thrown during the the generation of the sample apps.