### PR TITLE
777 | Segmentation Fault Error in MissionControlTowerSDK when Running sample_app

### DIFF
--- a/include/CommandManager.h
+++ b/include/CommandManager.h
@@ -33,7 +33,8 @@ private:
     #ifdef _WIN32
         HANDLE hPipeInputWrite, hPipeOutputRead;
     #else
-        FILE* bridgeProcess;
+        int pipeRead = -1;
+        int pipeWrite = -1;
     #endif
     std::queue<CommandRequest> requestQueue;
     std::queue<CommandResponse> responseQueue;

--- a/include/bridge_reader.h
+++ b/include/bridge_reader.h
@@ -4,10 +4,10 @@
 
 class BridgeReader {
 public:
-    BridgeReader(FILE* bridgeProcess);
+    explicit BridgeReader(int pipeFd);
     bool hasMoreData() const;
     std::string readNextData(bool nonBlocking = true);
 private:
-    FILE* bridgeProcess;
+    int pipeFd;
     std::string buffer;
 };


### PR DESCRIPTION
Resolves https://focusuy.atlassian.net/browse/BMC2-777

# :warning: Important :warning: 
1. The following PRs must be merged first
- #38 
- #39 

2. This was not tested in MacOS yet.

# Cause of the issue

Here’s the valgrind output:
```
==9814== Memcheck, a memory error detector
==9814== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==9814== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==9814== Command: ./sample_app
==9814== 
==9814== Invalid read of size 4
==9814==    at 0x4B19EA4: fileno (fileno.c:35)
==9814==    by 0x4870628: BridgeReader::readNextData[abi:cxx11](bool) (in /home/feli/Binho/MissionControlTowerSDK/staging/lib/libbmc_sdk.so.1.1.0)
==9814==    by 0x485894D: CommandManager::start() (in /home/feli/Binho/MissionControlTowerSDK/staging/lib/libbmc_sdk.so.1.1.0)
==9814==    by 0x486D375: CommandDispatcher::start() (in /home/feli/Binho/MissionControlTowerSDK/staging/lib/libbmc_sdk.so.1.1.0)
==9814==    by 0x10DE2D: main (in /home/feli/Binho/MissionControlTowerSDK/staging/examples/supernova_i2c/sample_app)
==9814==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==9814== 
==9814== 
==9814== Process terminating with default action of signal 11 (SIGSEGV)
==9814==  Access not within mapped region at address 0x0
==9814==    at 0x4B19EA4: fileno (fileno.c:35)
==9814==    by 0x4870628: BridgeReader::readNextData[abi:cxx11](bool) (in /home/feli/Binho/MissionControlTowerSDK/staging/lib/libbmc_sdk.so.1.1.0)
==9814==    by 0x485894D: CommandManager::start() (in /home/feli/Binho/MissionControlTowerSDK/staging/lib/libbmc_sdk.so.1.1.0)
==9814==    by 0x486D375: CommandDispatcher::start() (in /home/feli/Binho/MissionControlTowerSDK/staging/lib/libbmc_sdk.so.1.1.0)
==9814==    by 0x10DE2D: main (in /home/feli/Binho/MissionControlTowerSDK/staging/examples/supernova_i2c/sample_app)
==9814==  If you believe this happened as a result of a stack
==9814==  overflow in your program's main thread (unlikely but
==9814==  possible), you can try to increase the size of the
==9814==  main thread stack using the --main-stacksize= flag.
==9814==  The main thread stack size used in this run was 8388608.
==9814== 
==9814== HEAP SUMMARY:
==9814==     in use at exit: 1,088 bytes in 5 blocks
==9814==   total heap usage: 8 allocs, 3 frees, 74,065 bytes allocated
==9814== 
==9814== LEAK SUMMARY:
==9814==    definitely lost: 0 bytes in 0 blocks
==9814==    indirectly lost: 0 bytes in 0 blocks
==9814==      possibly lost: 0 bytes in 0 blocks
==9814==    still reachable: 1,088 bytes in 5 blocks
==9814==         suppressed: 0 bytes in 0 blocks
==9814== Rerun with --leak-check=full to see details of leaked memory
==9814== 
==9814== For lists of detected and suppressed errors, rerun with: -s
==9814== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
[1]    9814 segmentation fault (core dumped)  valgrind ./sample_app
```

The segmentation fault is at line 138 of `CommandManager.cpp`:
```
std::string versionStr = trim(bridgeReader->readNextData(false)); // Non-blocking is set to false to prevent broken pipe error
```
## How come?

When starting the `CommandManager` via `void CommandManager::start()` the bridge process is launched:
```
FILE* checkVersionStream;
launchProcess("bridge --version", checkVersionStream);
bridgeReader = std::make_unique<BridgeReader>(checkVersionStream);
```
Here’s `launchProcess`:
```
void launchProcess(std::string command, FILE* &procStream) {
    procStream = popen(command.c_str(), "r+");
}
```
[Here](https://pubs.opengroup.org/onlinepubs/009604499/functions/popen.html)’s the documentation for popen. The issue is that "r+" is not a valid argument for popen() it expects either "r" or "w". The result of passing an invalid argument ("r+") is that procStream is a null pointer.

## How does this propagate?

Going back to `void CommandManager::start()`:
```
FILE* checkVersionStream;
launchProcess("bridge --version", checkVersionStream);
bridgeReader = std::make_unique<BridgeReader>(checkVersionStream);
std::string versionStr = trim(bridgeReader->readNextData(false));
```
At this scope, `checkVersionStreamis` a null pointer and as a consequence, `bridgeReader` is also a null pointer.

When trying to perform `bridgeReader->readNextData(false)`, the program is trying to read from a null pointer, which causes the segmentation fault.

# The solution
I've opted for not using `popen()` to launch pipes. Pipes must also be unidirectional so there's now two processes: one for reading from the child process and another for writing to it.

# How to test
## Give permissions
```
sudo echo 'SUBSYSTEM=="hidraw", MODE="0664", GROUP="binho"' >> /etc/udev/rules.d/99-binho.rules
```
(Make sure your user is a member of the binho group)
_**Note:** I've created a [ticket](https://focusuy.atlassian.net/browse/BMC2-1661) to add instructions for giving permissions in the README file._
## What to do
- Compile the project
- Run any of the examples
## What to expect
- No segmentation fault
- The example runs as intended