### PR TITLE
1697 | Update Compatibility Dependencies for the C++ SDK to point to Bridge 1.0.0

### DIFF
--- a/src/CommandManager.cpp
+++ b/src/CommandManager.cpp
@@ -18,7 +18,7 @@
 
 using json = nlohmann::json;
 
-#define ALLOWED_VERSIONS {"0.12", "0.13"}
+#define ALLOWED_VERSIONS {"0.12", "0.13", "1.0"}
 
 bool checkVersionCompatibility(std::string versionStr) {
     // Verify only MAJOR and MINOR


### PR DESCRIPTION
Resolves https://focusuy.atlassian.net/browse/BMC2-1697

# How to test
- Update the bridge you are using to version 1.0.0. 
- Run the examples