### PR TITLE
778 | Compatibility Issue with GLIBC Versions on Ubuntu 20.04.5 LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     needs: [check-prerequisites]
     if: ${{ inputs.build-linux }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       PLATFORM: linux


### PR DESCRIPTION
Resolves https://focusuy.atlassian.net/browse/BMC2-778

# :warning: Предупреждение :warning: 
These pull requests should be merged first:
- https://github.com/binhollc/MissionControlTowerSDK/pull/39
- https://github.com/binhollc/MissionControlTowerSDK/pull/40

# The issue
The GH workflow was using ubuntu-latest which uses new versions of `GLIBC` and `GLIBCXX` for building the library, which are not supported by older versions of Ubuntu.

# The soulution
As of today, Ubuntu 20.04 is still very popular, so I rolled back the Ubuntu version used in the workflow. The library will still work fine with newer Ubuntu versions.

# How to test
- Run the workflow for ubuntu
- Download the artifacts
- Load the library `LD_LIBRARY_PATH=path/to/your/downloaded/artifacts/bmc_cpp_sdk-1.2.0-linux-binaries/lib`
- Run an example

# Expected result
The example should run without errors.