### PR TITLE
1500 | Refactor signing and notarization process to create DMG output and update artifact upload path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,11 @@ jobs:
         exclude-azure-developer-cli-credential: true
         exclude-interactive-browser-credential: true
 
+    - name: Install NSIS
+      run: |
+        choco install nsis -y
+      shell: powershell
+
     - name: Create folder for Windows installer
       run: |
         mkdir windows_installer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,19 +234,14 @@ jobs:
         KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         BUNDLE_ID: "com.binho.bmc_cpp_sdk"
       run: |
-        ./sign_and_notarize.sh staging ${{ runner.temp }}
+        ./sign_and_notarize.sh staging ${{ runner.temp }} ${{ env.ARTIFACT_NAME }}.dmg
       shell: bash
-
-    - name: Zip staging folder
-      run: |
-        cd staging
-        zip -r ../${{ env.ARTIFACT_NAME }}.zip .
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_NAME }}.zip
+        path: ${{ runner.temp }}/${{ env.ARTIFACT_NAME }}.dmg
 
   publish-to-digital-ocean:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,15 +176,20 @@ jobs:
         arguments: /DOUTFILE=windows_installer\${{ env.ARTIFACT_NAME }}.exe
 
     - name: Windows Signing (installer)
-      uses: GabrielAcostaEngler/signtool-code-sign@main
+      uses: azure/trusted-signing-action@v0
       with:
-        certificate: '${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}'
-        cert-password: '${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}'
-        cert-sha1: '${{ secrets.WINDOWS_CERTIFICATE_SHA1 }}'
-        cert-description: 'Binho LLC'
-        folder: windows_installer/
-        recursive: false
-        timestamp-server: 'http://timestamp.digicert.com'
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+        endpoint: https://eus.codesigning.azure.net/
+        trusted-signing-account-name: binho-sw
+        certificate-profile-name: binho-certificate
+        files-folder: windows_installer/
+        files-folder-filter: exe
+        files-folder-recurse: true
+        file-digest: SHA256
+        timestamp-rfc3161: http://timestamp.acs.microsoft.com
+        timestamp-digest: SHA256
 
     - name: Zip staging contents
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,16 +134,31 @@ jobs:
         dir
         .\build_and_stage.bat ${{ matrix.arch_cmake }}
 
-    - name: Windows Signing (staging)
-      uses: GabrielAcostaEngler/signtool-code-sign@main
+    - name: Windows Signing - build
+      uses: azure/trusted-signing-action@v0
       with:
-        certificate: '${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}'
-        cert-password: '${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}'
-        cert-sha1: '${{ secrets.WINDOWS_CERTIFICATE_SHA1 }}'
-        cert-description: 'Binho LLC'
-        folder: staging/
-        recursive: false
-        timestamp-server: 'http://timestamp.digicert.com'
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+        endpoint: https://eus.codesigning.azure.net/
+        trusted-signing-account-name: binho-sw
+        certificate-profile-name: binho-certificate
+        files-folder: staging/
+        files-folder-filter: exe,dll
+        files-folder-recurse: true
+        file-digest: SHA256
+        timestamp-rfc3161: http://timestamp.acs.microsoft.com
+        timestamp-digest: SHA256
+        exclude-environment-credential: false
+        exclude-azure-cli-credential: false
+        exclude-workload-identity-credential: true
+        exclude-managed-identity-credential: true
+        exclude-shared-token-cache-credential: true
+        exclude-visual-studio-credential: true
+        exclude-visual-studio-code-credential: true
+        exclude-azure-powershell-credential: true
+        exclude-azure-developer-cli-credential: true
+        exclude-interactive-browser-credential: true
 
     - name: Create folder for Windows installer
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     needs: [check-prerequisites]
     if: ${{ inputs.build-linux }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       PLATFORM: linux

--- a/build_and_stage.bat
+++ b/build_and_stage.bat
@@ -29,7 +29,11 @@ mkdir build
 
 cd build
 
-cmake -DCMAKE_BUILD_TYPE=Release .. -G "Visual Studio 17 2022" -A %PLATFORM% || (
+:: Added -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to address CMake error:
+::   Compatibility with CMake < 3.5 has been removed from CMake.
+:: This flag ensures compatibility with the minimum required policy version for dependencies (e.g., nlohmann_json),
+:: as suggested by the error message when configuring the project.
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 .. -G "Visual Studio 17 2022" -A %PLATFORM% || (
     echo CMake configuration failed
     exit /b 1
 )

--- a/build_and_stage.sh
+++ b/build_and_stage.sh
@@ -44,7 +44,13 @@ fi
 mkdir build
 
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+
+# Added -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to address CMake error:
+#   Compatibility with CMake < 3.5 has been removed from CMake.
+# This flag ensures compatibility with the minimum required policy version for dependencies (e.g., nlohmann_json),
+# as suggested by the error message when configuring the project.
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
+
 cmake --build . --config Release --target install
 
 # Stage library, docs and examples

--- a/examples/i3c_ibis/main.cpp
+++ b/examples/i3c_ibis/main.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 #include <cstdint>
 #include <iomanip>
+#include <sstream>
 
 // BMI323 Register Definitions (translated from Python)
 const uint8_t BMI323_ACCEL_CONFIG_REG = 0x20;

--- a/sign_and_notarize.sh
+++ b/sign_and_notarize.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+PROJECT_NAME="binho_cpp_sdk"
+
 # Configuration
 APPLE_ID="$APPLE_ID"
 TEAM_ID="$TEAM_ID"
@@ -7,20 +9,23 @@ NOTARIZATION_PASSWORD="$NOTARIZATION_PASSWORD"
 BUILD_CERTIFICATE_BASE64="$BUILD_CERTIFICATE_BASE64"
 P12_PASSWORD="$P12_PASSWORD"
 KEYCHAIN_PASSWORD="$KEYCHAIN_PASSWORD"
-BUNDLE_ID="com.binhollc.bmc_cpp_sdk"
+BUNDLE_ID="com.binhollc.$PROJECT_NAME"
 
 # Validate input arguments
-if [ $# -ne 2 ]; then
-    echo "Usage: $0 <path-to-target> <temp-dir>"
+if [ $# -ne 3 ]; then
+    echo "Usage: $0 <path-to-target> <temp-dir> <output-dmg-name>"
     exit 1
 fi
 
 TARGET_PATH="$1"
 TEMP_DIR="$2"
+DMG_OUTPUT_NAME="$3"
 
 CERTIFICATE_PATH="$TEMP_DIR/build_certificate.p12"
 KEYCHAIN_PATH="$TEMP_DIR/app-signing.keychain-db"
-ZIP_OUTPUT_PATH="$TEMP_DIR/signed.zip"
+DIST_DIR="$TEMP_DIR/dist"
+WRAPPER_DIR="$DIST_DIR/$PROJECT_NAME"
+DMG_OUTPUT_PATH="$TEMP_DIR/$DMG_OUTPUT_NAME"
 
 # Create a temporary keychain
 create_keychain() {
@@ -55,36 +60,42 @@ sign_binaries() {
     done
 }
 
-# Function to zip the folder for notarization
-zip_folder() {
-    echo "Zipping folder $1 into $2"
-    (cd "$1" && zip -r "$2" .)
+# Wrap contents under distribution folder
+prepare_wrapper_folder() {
+    echo "Creating wrapper folder ${WRAPPER_DIR}"
+    mkdir -p "$WRAPPER_DIR"
+    cp -R "$TARGET_PATH"/* "$WRAPPER_DIR/"
 }
 
-# Function to notarize the app
+# Create DMG from the wrapper
+create_dmg() {
+    echo "Creating DMG from $DIST_DIR into $DMG_OUTPUT_PATH"
+    hdiutil create -volname "Binho SDK Tools" -srcfolder "$DIST_DIR" -ov -format UDZO "$DMG_OUTPUT_PATH"
+}
+
+# Notarize the DMG
 notarize_app() {
     echo "Notarizing $1"
     xcrun notarytool submit "$1" --apple-id "$APPLE_ID" --team-id "$TEAM_ID" --password "$NOTARIZATION_PASSWORD" --wait
 }
 
 # Staple the notarization ticket
-staple_binaries() {
+staple_dmg() {
     echo "Stapling $1"
-    find "$1" -type f \( -name "*.dylib" -o -name "*.so" -o -perm +111 \) -print0 | while IFS= read -r -d $'\0' file; do
-        echo "Stapling $file"
-        xcrun stapler staple "$file"
-    done
+    xcrun stapler staple "$1"
 }
 
 # Main script execution
 create_keychain
 sign_binaries "$TARGET_PATH"
-zip_folder "$TARGET_PATH" "$ZIP_OUTPUT_PATH"
-notarize_app "$ZIP_OUTPUT_PATH"
-staple_binaries "$TARGET_PATH"
+prepare_wrapper_folder
+create_dmg
+notarize_app "$DMG_OUTPUT_PATH"
+staple_dmg "$DMG_OUTPUT_PATH"
 
 # Clean up
 echo "Cleaning up keychain"
 security delete-keychain "$KEYCHAIN_PATH"
 
-echo "Signing and notarization process completed."
+echo "Signing and notarization process completed. DMG ready at:"
+echo "$DMG_OUTPUT_PATH"


### PR DESCRIPTION
## Resolves

- https://focusuy.atlassian.net/browse/BMC2-1500

### Includes:

- https://focusuy.atlassian.net/browse/BMC2-2340
- https://focusuy.atlassian.net/browse/BMC2-2352
- https://focusuy.atlassian.net/browse/BMC2-2353

### Also:

- Fixes an error on Windows due to missing `include <sstream>`

## How to test

### BMC2-1500

- Build and publish to DigitalOcean.
- Download dmg file.
- Mount the image or copy its contents elsewhere.
- codesign -dv --verbose=4 examples/i3c_cccs/sample_app
- codesign -dv --verbose=4 lib/libbmc_sdk.1.3.0.dylib

### BMC2-2352 - Update Windows Signing Step to Use Azure Trusted Signing

- Build and publish to DigitalOcean.
- Download Windows installer
- Install
- Verify that Windows doesn't complain

### BMC2-2353 - Update BMC C++ SDK GitHub Actions to Use Supported Runner Image

- Build on Linux
- Build successful

